### PR TITLE
fix: Github ref_name env var reference

### DIFF
--- a/.github/workflows/gradle-publish-snapshot.yml
+++ b/.github/workflows/gradle-publish-snapshot.yml
@@ -37,4 +37,4 @@ jobs:
           PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}
           PUBLISH_GPG_PRIVATE_KEY: ${{ secrets.PUBLISH_GPG_PRIVATE_KEY }}
           PUBLISH_GPG_PASSPHRASE: ${{ secrets.PUBLISH_GPG_PASSPHRASE }}
-        run: ./gradlew -Pversion=0.0.0-${{github.GITHUB_REF_NAME}}-SNAPSHOT publish
+        run: ./gradlew -Pversion=0.0.0-${{ github.ref_name }}-SNAPSHOT publish


### PR DESCRIPTION
Env var usage was wrong. The env var GITHUB_REF_NAME has to be addressed with `${{ github.ref_name }}`