### PR TITLE
feat: Introduce common SchemaStore interface for schema validations i…

### DIFF
--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/schema/SchemaStore.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/schema/SchemaStore.java
@@ -1,0 +1,13 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package de.telekom.eni.pandora.horizon.schema;
+
+import org.everit.json.schema.Schema;
+
+public interface SchemaStore {
+    Schema getSchemaForEventType(String environment, String eventType, String hub, String team);
+
+    void pollSchemas();
+}


### PR DESCRIPTION
- Add common SchemaStore interface for implementations of schema validations in starlight
- Starlight will define a noop implementation as long as no library brings a real implementation