### PR TITLE
feat: Add option to configure kafka producer maxRequestSize

### DIFF
--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/kafka/config/KafkaProperties.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/kafka/config/KafkaProperties.java
@@ -42,6 +42,9 @@ public class KafkaProperties {
     @Value("${acks:1}")
     private String acks;
 
+    @Value("${maxRequestSize:1048576}")
+    private String maxRequestSize;
+
     private Compression compression = new Compression();
 
 }

--- a/horizon-spring-boot-autoconfigure/src/main/java/de/telekom/eni/pandora/horizon/autoconfigure/kafka/KafkaAutoConfiguration.java
+++ b/horizon-spring-boot-autoconfigure/src/main/java/de/telekom/eni/pandora/horizon/autoconfigure/kafka/KafkaAutoConfiguration.java
@@ -35,6 +35,7 @@ public class KafkaAutoConfiguration {
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.ACKS_CONFIG, kafkaProperties.getAcks());
+        props.put(ProducerConfig.MAX_REQUEST_SIZE_CONFIG, kafkaProperties.getMaxRequestSize());
 
         final var compression = kafkaProperties.getCompression();
         log.info("Compression is {}", compression.isEnabled() ? "enabled" : "disabled");


### PR DESCRIPTION
- allow configurability of kafka producer maxRequestSize as long as we still use custom kafkatemplate autoconfiguration