### PR TITLE
Feature new mongo query to fix processed msg

### DIFF
--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -36,8 +36,6 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     Slice<MessageStateMongoDocument> findStatusFailedWithCallbackExceptionAsc();
     @Query(value = "{ \"error.type\": \"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\" , \"status\": { \"$eq\": \"FAILED\" } }", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findStatusFailedWithCallbackExceptionAsc(Pageable pageable);
-    @Query(value = "{ \"error.type\": \"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\" , \"status\": { \"$eq\": \"FAILED\" } }", sort = "{timestamp: 1}")
-    Slice<MessageStateMongoDocument> findByFailedWithCallbackExceptionAndSubscriptionIdsAndTimestampLessThanEqual(Status status, List<String> subscriptionIds, Date upperTimestampThreshold, Pageable pageable);
 
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: ?2}", sort = "{timestamp: 1}")
     List<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(List<Status> status, DeliveryType deliveryType, String subscriptionId);

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -32,8 +32,6 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     Slice<MessageStateMongoDocument> findByDeliveryTypeAndStatusAndModifiedLessThanEqual(DeliveryType deliveryType, Status status, Date upperTimestampThreshold);
     Slice<MessageStateMongoDocument> findByDeliveryTypeAndStatusAndModifiedLessThanEqual(DeliveryType deliveryType, Status status, Date upperTimestampThreshold, Pageable pageable);
 
-    Slice<MessageStateMongoDocument> findByStatusAndSubscriptionIdsAndTimestampLessThanEqual(Status status, List<String> subscriptionIds, Date upperTimestampThreshold, Pageable pageable);
-
     @Query(value = "{ \"error.type\": \"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\" , \"status\": { \"$eq\": \"FAILED\" } }", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findStatusFailedWithCallbackExceptionAsc();
     @Query(value = "{ \"error.type\": \"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\" , \"status\": { \"$eq\": \"FAILED\" } }", sort = "{timestamp: 1}")
@@ -58,6 +56,8 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     @Query(value = "{$or:[{\"error.type\":{ $exists: false}},{\"error.type\":\"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\"}], status:{ $in: ?0 }, subscriptionId:{ $in: ?1 }, modified: { $lte: ?2 } }", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findByStatusInPlusCallbackUrlNotFoundExceptionAsc(List<Status> status, List<String> subscriptionIds, Date timestampOlderThan, Pageable pageable);
 
+    @Query(value = "{$or:[{\"status\":{ $eq: \"WAITING\"}},{\"error.type\":\"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\"}], status:{ $in: ?0 }, subscriptionId:{ $in: ?1 }, modified: { $lte: ?2 }}", sort = "{timestamp: 1}")
+    Slice<MessageStateMongoDocument> findByWaitingOrFailedWithCallbackExceptionAndSubscriptionIdsAndTimestampLessThanEqual(Status status, List<String> subscriptionIds, Date upperTimestampThreshold, Pageable pageable);
 
     List<MessageStateMongoDocument> findByMultiplexedFrom(String multiplexedFromId);
 

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -57,7 +57,7 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     Slice<MessageStateMongoDocument> findByStatusInPlusCallbackUrlNotFoundExceptionAsc(List<Status> status, List<String> subscriptionIds, Date timestampOlderThan, Pageable pageable);
 
     @Query(value = "{$or:[{\"status\":{ $eq: \"WAITING\"}},{\"error.type\":\"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\"}], status:{ $in: ?0 }, subscriptionId:{ $in: ?1 }, modified: { $lte: ?2 }}", sort = "{timestamp: 1}")
-    Slice<MessageStateMongoDocument> findByWaitingOrFailedWithCallbackExceptionAndSubscriptionIdsAndTimestampLessThanEqual(List<Status> status, List<String> subscriptionIds, Date upperTimestampThreshold, Pageable pageable);
+    Slice<MessageStateMongoDocument> findByStatusWaitingOrFailedWithCallbackExceptionAndSubscriptionIdsAndTimestampLessThanEqual(List<Status> status, List<String> subscriptionIds, Date upperTimestampThreshold, Pageable pageable);
 
     List<MessageStateMongoDocument> findByMultiplexedFrom(String multiplexedFromId);
 

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -57,7 +57,7 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     Slice<MessageStateMongoDocument> findByStatusInPlusCallbackUrlNotFoundExceptionAsc(List<Status> status, List<String> subscriptionIds, Date timestampOlderThan, Pageable pageable);
 
     @Query(value = "{$or:[{\"status\":{ $eq: \"WAITING\"}},{\"error.type\":\"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\"}], status:{ $in: ?0 }, subscriptionId:{ $in: ?1 }, modified: { $lte: ?2 }}", sort = "{timestamp: 1}")
-    Slice<MessageStateMongoDocument> findByWaitingOrFailedWithCallbackExceptionAndSubscriptionIdsAndTimestampLessThanEqual(Status status, List<String> subscriptionIds, Date upperTimestampThreshold, Pageable pageable);
+    Slice<MessageStateMongoDocument> findByWaitingOrFailedWithCallbackExceptionAndSubscriptionIdsAndTimestampLessThanEqual(List<Status> status, List<String> subscriptionIds, Date upperTimestampThreshold, Pageable pageable);
 
     List<MessageStateMongoDocument> findByMultiplexedFrom(String multiplexedFromId);
 

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -32,16 +32,17 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     Slice<MessageStateMongoDocument> findByDeliveryTypeAndStatusAndModifiedLessThanEqual(DeliveryType deliveryType, Status status, Date upperTimestampThreshold);
     Slice<MessageStateMongoDocument> findByDeliveryTypeAndStatusAndModifiedLessThanEqual(DeliveryType deliveryType, Status status, Date upperTimestampThreshold, Pageable pageable);
 
+    Slice<MessageStateMongoDocument> findByStatusAndSubscriptionIdsAndTimestampLessThanEqual(Status status, List<String> subscriptionIds, Date upperTimestampThreshold, Pageable pageable);
 
     @Query(value = "{ \"error.type\": \"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\" , \"status\": { \"$eq\": \"FAILED\" } }", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findStatusFailedWithCallbackExceptionAsc();
     @Query(value = "{ \"error.type\": \"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\" , \"status\": { \"$eq\": \"FAILED\" } }", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findStatusFailedWithCallbackExceptionAsc(Pageable pageable);
-
+    @Query(value = "{ \"error.type\": \"de.telekom.horizon.dude.exception.CallbackUrlNotFoundException\" , \"status\": { \"$eq\": \"FAILED\" } }", sort = "{timestamp: 1}")
+    Slice<MessageStateMongoDocument> findByFailedWithCallbackExceptionAndSubscriptionIdsAndTimestampLessThanEqual(Status status, List<String> subscriptionIds, Date upperTimestampThreshold, Pageable pageable);
 
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: ?2}", sort = "{timestamp: 1}")
     List<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(List<Status> status, DeliveryType deliveryType, String subscriptionId);
-
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: ?2}", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(List<Status> status, DeliveryType deliveryType, String subscriptionId, Pageable pageable);
 

--- a/horizon-core/src/test/java/de/telekom/eni/pandora/horizon/mongo/MessageStateMongoDocumentTest.java
+++ b/horizon-core/src/test/java/de/telekom/eni/pandora/horizon/mongo/MessageStateMongoDocumentTest.java
@@ -67,7 +67,7 @@ public class MessageStateMongoDocumentTest {
 
     @BeforeAll
     static void initContainer() {
-//        mongoDBContainer.start();
+        //mongoDBContainer.start();
 
         testPartition = 123;
         testDeliveryType = DeliveryType.CALLBACK;


### PR DESCRIPTION
- Add a new query for mongoDB to search for WAITING events or events with a CallbackUrlNotFoundException