### PR TITLE
Fix datetime format of lastOpened and lastModified in CircuitBreakerMessage

### DIFF
--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/model/meta/CircuitBreakerMessage.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/model/meta/CircuitBreakerMessage.java
@@ -26,7 +26,7 @@ public class CircuitBreakerMessage {
 
     private String eventType;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'hh:mm:ssX", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssX", timezone = "UTC")
     private Date lastModified;
 
     private String originMessageId;
@@ -35,7 +35,7 @@ public class CircuitBreakerMessage {
 
     private String environment;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'hh:mm:ssX", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssX", timezone = "UTC")
     private Date lastOpened;
 
     private int loopCounter;


### PR DESCRIPTION
This PR solves a problem which caused the mentioned timestamps to use 12h format instead of 24h format.