### PR TITLE
feat: added mongo db query required for offset-based sse

### DIFF
--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -7,6 +7,7 @@ package de.telekom.eni.pandora.horizon.mongo.repository;
 import de.telekom.eni.pandora.horizon.model.event.DeliveryType;
 import de.telekom.eni.pandora.horizon.model.event.Status;
 import de.telekom.eni.pandora.horizon.mongo.model.MessageStateMongoDocument;
+import org.bson.types.ObjectId;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -41,6 +42,11 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     List<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(List<Status> status, DeliveryType deliveryType, String subscriptionId);
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: ?2}", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(List<Status> status, DeliveryType deliveryType, String subscriptionId, Pageable pageable);
+
+    @Query(value = "{'_id':  {$gt:  ?0}, deliveryType: ?1}", sort = "{timestamp: 1}")
+    List<MessageStateMongoDocument> findByDeliveryTypeAndAfterObjectIdAsc(DeliveryType deliveryType, ObjectId objectId);
+    @Query(value = "{'_id':  {$gt:  ?0}, deliveryType: ?1}", sort = "{timestamp: 1}")
+    Slice<MessageStateMongoDocument> findByDeliveryTypeAndAfterObjectIdAsc(DeliveryType deliveryType, ObjectId objectId, Pageable pageable);
 
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: {$in:  ?2}}", sort = "{timestamp: 1}")
     List<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdsAsc(List<Status> status, DeliveryType deliveryType, List<String> subscriptionIds);

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -43,10 +43,10 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: ?2}", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(List<Status> status, DeliveryType deliveryType, String subscriptionId, Pageable pageable);
 
-    @Query(value = "{deliveryType: ?0, subscriptionId: ?1, timestamp: { $gt: ?0 }}", sort = "{timestamp: 1}")
-    List<MessageStateMongoDocument> findByDeliveryTypeAndSubscriptionAndTimestampGreaterThanAsc(DeliveryType deliveryType, String subscriptionId, Date timestamp);
-    @Query(value = "{deliveryType: ?0, subscriptionId: ?1, timestamp: { $gt: ?0 }}", sort = "{timestamp: 1}")
-    Slice<MessageStateMongoDocument> findByDeliveryTypeAndSubscriptionAndTimestampGreaterThanAsc(DeliveryType deliveryType, String subscriptionId, Date timestamp, Pageable pageable);
+    @Query(value = "{deliveryType: ?0, subscriptionId: ?1, timestamp: { $gt: ?2 }}", sort = "{timestamp: 1}")
+    List<MessageStateMongoDocument> findByDeliveryTypeAndSubscriptionIdAndTimestampGreaterThanAsc(DeliveryType deliveryType, String subscriptionId, Date timestamp);
+    @Query(value = "{deliveryType: ?0, subscriptionId: ?1, timestamp: { $gt: ?2 }}", sort = "{timestamp: 1}")
+    Slice<MessageStateMongoDocument> findByDeliveryTypeAndSubscriptionIdAndTimestampGreaterThanAsc(DeliveryType deliveryType, String subscriptionId, Date timestamp, Pageable pageable);
 
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: {$in:  ?2}}", sort = "{timestamp: 1}")
     List<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdsAsc(List<Status> status, DeliveryType deliveryType, List<String> subscriptionIds);

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -43,9 +43,9 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: ?2}", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(List<Status> status, DeliveryType deliveryType, String subscriptionId, Pageable pageable);
 
-    @Query(value = "{deliveryType: ?0, subscriptionId: {$in:  ?1}, timestamp: { $gt: ?0 }}", sort = "{timestamp: 1}")
+    @Query(value = "{deliveryType: ?0, subscriptionId: ?1, timestamp: { $gt: ?0 }}", sort = "{timestamp: 1}")
     List<MessageStateMongoDocument> findByDeliveryTypeAndSubscriptionAndTimestampGreaterThanAsc(DeliveryType deliveryType, String subscriptionId, Date timestamp);
-    @Query(value = "{deliveryType: ?0, subscriptionId: {$in:  ?1}, timestamp: { $gt: ?0 }}", sort = "{timestamp: 1}")
+    @Query(value = "{deliveryType: ?0, subscriptionId: ?1, timestamp: { $gt: ?0 }}", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findByDeliveryTypeAndSubscriptionAndTimestampGreaterThanAsc(DeliveryType deliveryType, String subscriptionId, Date timestamp, Pageable pageable);
 
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: {$in:  ?2}}", sort = "{timestamp: 1}")

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -43,10 +43,10 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: ?2}", sort = "{timestamp: 1}")
     Slice<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(List<Status> status, DeliveryType deliveryType, String subscriptionId, Pageable pageable);
 
-    @Query(value = "{'_id':  {$gt:  ?0}, deliveryType: ?1}", sort = "{timestamp: 1}")
-    List<MessageStateMongoDocument> findByDeliveryTypeAndAfterObjectIdAsc(ObjectId objectId, DeliveryType deliveryType);
-    @Query(value = "{'_id':  {$gt:  ?0}, deliveryType: ?1}", sort = "{timestamp: 1}")
-    Slice<MessageStateMongoDocument> findByDeliveryTypeAndAfterObjectIdAsc(ObjectId objectId, DeliveryType deliveryType, Pageable pageable);
+    @Query(value = "{deliveryType: ?0, subscriptionId: {$in:  ?1}, timestamp: { $gt: ?0 }}", sort = "{timestamp: 1}")
+    List<MessageStateMongoDocument> findByDeliveryTypeAndSubscriptionAndTimestampGreaterThanAsc(DeliveryType deliveryType, String subscriptionId, Date timestamp);
+    @Query(value = "{deliveryType: ?0, subscriptionId: {$in:  ?1}, timestamp: { $gt: ?0 }}", sort = "{timestamp: 1}")
+    Slice<MessageStateMongoDocument> findByDeliveryTypeAndSubscriptionAndTimestampGreaterThanAsc(DeliveryType deliveryType, String subscriptionId, Date timestamp, Pageable pageable);
 
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: {$in:  ?2}}", sort = "{timestamp: 1}")
     List<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdsAsc(List<Status> status, DeliveryType deliveryType, List<String> subscriptionIds);

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/mongo/repository/MessageStateMongoRepo.java
@@ -44,9 +44,9 @@ public interface MessageStateMongoRepo extends MongoRepository<MessageStateMongo
     Slice<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdAsc(List<Status> status, DeliveryType deliveryType, String subscriptionId, Pageable pageable);
 
     @Query(value = "{'_id':  {$gt:  ?0}, deliveryType: ?1}", sort = "{timestamp: 1}")
-    List<MessageStateMongoDocument> findByDeliveryTypeAndAfterObjectIdAsc(DeliveryType deliveryType, ObjectId objectId);
+    List<MessageStateMongoDocument> findByDeliveryTypeAndAfterObjectIdAsc(ObjectId objectId, DeliveryType deliveryType);
     @Query(value = "{'_id':  {$gt:  ?0}, deliveryType: ?1}", sort = "{timestamp: 1}")
-    Slice<MessageStateMongoDocument> findByDeliveryTypeAndAfterObjectIdAsc(DeliveryType deliveryType, ObjectId objectId, Pageable pageable);
+    Slice<MessageStateMongoDocument> findByDeliveryTypeAndAfterObjectIdAsc(ObjectId objectId, DeliveryType deliveryType, Pageable pageable);
 
     @Query(value = "{status: {$in:  ?0}, deliveryType: ?1, subscriptionId: {$in:  ?2}}", sort = "{timestamp: 1}")
     List<MessageStateMongoDocument> findByStatusInAndDeliveryTypeAndSubscriptionIdsAsc(List<Status> status, DeliveryType deliveryType, List<String> subscriptionIds);


### PR DESCRIPTION
Due to the nature of SSE (Server-Sent Events) being based on the HTTP protocol, data loss cannot be completely ruled out. For example, if a client abruptly disconnects from an SSE connection, it is possible that data might be successfully written to the TCP buffer of the underlying operating system, but never reach the client. The server, however, has no direct way of responding to any outstanding acknowledgements from the client and assumes in such cases that the message was successfully delivered. This can lead to data loss, which we aim to prevent within the scope of this epic.

To address this, this PR introduces a new MongoDB query which allows to search for entries that are newer than a given timestamp. This is a requirment for offset-based event-streaming in Horizon Pulsar.