### PR TITLE
feat: enable support for UUID v7 and v8

### DIFF
--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/model/event/validation/RegexPattern.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/model/event/validation/RegexPattern.java
@@ -7,5 +7,5 @@ package de.telekom.eni.pandora.horizon.model.event.validation;
 public class RegexPattern {
     public static final String ISO8601_TIME = "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?(?:Z|[+-][01]\\d:[0-5]\\d)$";
     public static final String EVENT_TYPE = "^[a-zA-Z0-9\\.\\-]*$";
-    public static final String UUID = "\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\b";
+    public static final String UUID = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$";
 }

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/model/event/validation/RegexPattern.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/model/event/validation/RegexPattern.java
@@ -7,5 +7,5 @@ package de.telekom.eni.pandora.horizon.model.event.validation;
 public class RegexPattern {
     public static final String ISO8601_TIME = "^(?:[1-9]\\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\\d|2[0-3]):[0-5]\\d:[0-5]\\d(?:\\.\\d{1,9})?(?:Z|[+-][01]\\d:[0-5]\\d)$";
     public static final String EVENT_TYPE = "^[a-zA-Z0-9\\.\\-]*$";
-    public static final String UUID = "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$";
+    public static final String UUID = "\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\b";
 }


### PR DESCRIPTION
This PR enables support for UUID v7 and v8 used for event IDs as the validation regex has been updated accordingly.