### PR TITLE
chore(deps): update spring boot version to 3.4.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # gradle plugins
-springBootVersion=3.2.2
+springBootVersion=3.4.2
 springDependencyManagementVersion=1.1.4
 sonarqubeVersion=4.4.1.3373
 

--- a/horizon-core/build.gradle
+++ b/horizon-core/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
 
-    testImplementation "de.bwaldvogel:mongo-java-server:1.44.0"
+    testImplementation "de.bwaldvogel:mongo-java-server:1.46.0"
 
     // local dependencies
     testImplementation project(':horizon-spring-boot-autoconfigure')


### PR DESCRIPTION
Updating to latest SpringBoot version 2.4.3 also allows us to call `isClosed()` on an application context to check whether the application is already shutting down. This is helpful for checking whether a process has been stopped by unexpectedly or due to a planned graceful shutdown.