### PR TITLE
feat(metrics): implement additional metric constants for schema validation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ everitJsonVersion=1.14.4
 # internal
 jsonFilterVersion=1.0.1
 
-version=5.0.1-SNAPSHOT
+version=5.1.0-SNAPSHOT

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/metrics/HorizonMetricsConstants.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/metrics/HorizonMetricsConstants.java
@@ -16,6 +16,9 @@ public class HorizonMetricsConstants {
     public static final String METRIC_INTERNAL_EXCEPTION_COUNT = "internal_exception_count";
     public static final String METRIC_PAYLOAD_SIZE_INCOMING = "payload_size_incoming";
     public static final String METRIC_PAYLOAD_SIZE_OUTGOING = "payload_size_outgoing";
+    public static final String METRIC_SCHEMA_VALIDATION_FAILURES = "schema_validation_failures";
+    public static final String METRIC_SCHEMA_VALIDATION_SUCCESS = "schema_validation_success";
+    public static final String METRIC_SCHEMA_VALIDATION_INVALID_SCHEMA = "schema_validation_invalid_schema";
 
     //Tags
     public static final String TAG_EVENT_TYPE = "event_type";

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/metrics/HorizonMetricsConstants.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/metrics/HorizonMetricsConstants.java
@@ -18,6 +18,8 @@ public class HorizonMetricsConstants {
     public static final String METRIC_PAYLOAD_SIZE_OUTGOING = "payload_size_outgoing";
     public static final String METRIC_SCHEMA_VALIDATION_FAILURES = "schema_validation_failures";
     public static final String METRIC_SCHEMA_VALIDATION_SUCCESS = "schema_validation_success";
+
+    // Not used yet, but reserved for future use with the new control-plane.
     public static final String METRIC_SCHEMA_VALIDATION_INVALID_SCHEMA = "schema_validation_invalid_schema";
 
     //Tags


### PR DESCRIPTION
This PR introduces three new constants to represent the metrics generated during schema-validation. The three metric values are the following:

**Name:** `METRIC_SCHEMA_VALIDATION_FAILURES`
**Description:** Represents the times a schema-validation has failed due to a non-compliant JSON body.


**Name:** `METRIC_SCHEMA_VALIDATION_SUCCESS`
**Description:** Represents the times a schema-validation has succeeded due to a compliant JSON body.


**Name:** `METRIC_SCHEMA_VALIDATION_INVALID_SCHEMA`
**Description:** Represents the times a schema-validation failed due to an invalid schema.
_See comment below_


_I'd appreciate your feedback team @telekom/pubsub-horizon!_