### PR TITLE
fix(cache): make jsonEntryMapEventBroadcaster in JsonCacheService optional

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ everitJsonVersion=1.14.4
 # internal
 jsonFilterVersion=1.0.1
 
-version=0.0.0-SNAPSHOT
+version=0.0.0-fix-circuit-breaker-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ everitJsonVersion=1.14.4
 # internal
 jsonFilterVersion=1.0.1
 
-version=0.0.0-fix-circuit-breaker-SNAPSHOT
+version=5.0.1-SNAPSHOT

--- a/horizon-core/src/test/java/de/telekom/eni/pandora/horizon/cache/service/JsonCacheServiceTest.java
+++ b/horizon-core/src/test/java/de/telekom/eni/pandora/horizon/cache/service/JsonCacheServiceTest.java
@@ -232,7 +232,6 @@ class JsonCacheServiceTest {
 
         // Verify results
         verify(hazelcastInstance, times(1)).getMap(TEST_MAP_NAME);
-        verify(mockMap, times(1)).addEntryListener(any(), eq(true));
         assertNotNull(result, "Map should be filled");
     }
 

--- a/horizon-core/src/test/java/de/telekom/eni/pandora/horizon/cache/service/JsonCacheServiceTest.java
+++ b/horizon-core/src/test/java/de/telekom/eni/pandora/horizon/cache/service/JsonCacheServiceTest.java
@@ -47,7 +47,6 @@ class JsonCacheServiceTest {
     void setUp() {
         hazelcastInstance = mock(HazelcastInstance.class);
         subscriptionsMongoRepo = mock(SubscriptionsMongoRepo.class);
-        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         IMap<String, HazelcastJsonValue> mockMap = mock(IMap.class);
 
         jsonCacheService = new JsonCacheService<>(
@@ -55,8 +54,7 @@ class JsonCacheServiceTest {
                 mockMap,
                 new ObjectMapper(),
                 hazelcastInstance,
-                TEST_MAP_NAME,
-                eventPublisher
+                TEST_MAP_NAME
         );
         jsonCacheService.setJsonCacheFallback(new SubscriptionCacheMongoFallback(subscriptionsMongoRepo, mongoProperties));
     }

--- a/horizon-spring-boot-autoconfigure/src/main/java/de/telekom/eni/pandora/horizon/autoconfigure/cache/JsonCacheAutoconfiguration.java
+++ b/horizon-spring-boot-autoconfigure/src/main/java/de/telekom/eni/pandora/horizon/autoconfigure/cache/JsonCacheAutoconfiguration.java
@@ -56,8 +56,9 @@ public class JsonCacheAutoconfiguration {
             log.error("Hazelcast map {} is not available", SUBSCRIPTION_RESOURCE_V1);
         }
 
-        var svc = new JsonCacheService<>(SubscriptionResource.class, map, mapper, hazelcastInstance,SUBSCRIPTION_RESOURCE_V1, applicationEventPublisher);
+        var svc = new JsonCacheService<>(SubscriptionResource.class, map, mapper, hazelcastInstance,SUBSCRIPTION_RESOURCE_V1);
         svc.setJsonCacheFallback(new SubscriptionCacheMongoFallback(subscriptionsMongoRepo, mongoProperties));
+        svc.setJsonEntryMapEventBroadcaster(new SubscriptionResourceEventBroadcaster(mapper, applicationEventPublisher));
         return svc;
     }
 
@@ -75,7 +76,7 @@ public class JsonCacheAutoconfiguration {
         var mapper = new ObjectMapper();
         mapper.registerModule(new JavaTimeModule());
 
-        return new JsonCacheService<>(CircuitBreakerMessage.class, map, mapper, hazelcastInstance, CIRCUITBREAKER_MAP, null);
+        return new JsonCacheService<>(CircuitBreakerMessage.class, map, mapper, hazelcastInstance, CIRCUITBREAKER_MAP);
     }
 
 }


### PR DESCRIPTION
This PR fixes a bug which occurred in the comet component as the `JsonCacheService` is used for the CircuitBreakerMessage type instead of the SubscriptionResource type, also the `JsonCacheService` should be fully generic without any specific logic.
