### PR TITLE
refactor(schema-validation): rename metric for schema-validation failure

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,4 +12,4 @@ everitJsonVersion=1.14.4
 # internal
 jsonFilterVersion=1.0.1
 
-version=5.1.0-SNAPSHOT
+version=5.1.1-SNAPSHOT

--- a/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/metrics/HorizonMetricsConstants.java
+++ b/horizon-core/src/main/java/de/telekom/eni/pandora/horizon/metrics/HorizonMetricsConstants.java
@@ -16,7 +16,7 @@ public class HorizonMetricsConstants {
     public static final String METRIC_INTERNAL_EXCEPTION_COUNT = "internal_exception_count";
     public static final String METRIC_PAYLOAD_SIZE_INCOMING = "payload_size_incoming";
     public static final String METRIC_PAYLOAD_SIZE_OUTGOING = "payload_size_outgoing";
-    public static final String METRIC_SCHEMA_VALIDATION_FAILURES = "schema_validation_failures";
+    public static final String METRIC_SCHEMA_VALIDATION_FAILURE = "schema_validation_failure";
     public static final String METRIC_SCHEMA_VALIDATION_SUCCESS = "schema_validation_success";
 
     // Not used yet, but reserved for future use with the new control-plane.


### PR DESCRIPTION
This PR simply changes `METRIC_SCHEMA_VALIDATION_FAILURES` into `METRIC_SCHEMA_VALIDATION_FAILURE` :)